### PR TITLE
Modify enableMultipleOverridesFor

### DIFF
--- a/src/urlhandler.ios.ts
+++ b/src/urlhandler.ios.ts
@@ -4,81 +4,71 @@ export { handleOpenURL } from './urlhandler.common';
 
 export const appDelegate = getAppDelegate();
 
-function enableMultipleOverridesFor(classRef, methodName) {
-    const prefix = '_';
-
-    Object.defineProperty(classRef.prototype, prefix + methodName, {
-        value: classRef.prototype[methodName] || (() => {}),
-        writable: true
-    });
-
-    Object.defineProperty(classRef.prototype, methodName, {
-        get: function () {
-            return classRef.prototype[prefix + methodName];
-        },
-        set: function (nextImplementation) {
-            const currentImplementation = classRef.prototype[prefix + methodName];
-
-            classRef.prototype[prefix + methodName] = function () {
-                const result = currentImplementation(...Array.from(arguments));
-                return nextImplementation(...Array.from(arguments), result);
-            };
-        }
-    });
+function enableMultipleOverridesFor(classRef, methodName, nextImplementation) {
+    const currentImplementation = classRef.prototype[methodName];
+    classRef.prototype[methodName] = function () {
+        const result = currentImplementation && currentImplementation.apply(currentImplementation, Array.from(arguments));
+        return nextImplementation.apply(nextImplementation, Array.from(arguments).concat([result]));
+    };
 }
 
-enableMultipleOverridesFor(appDelegate, 'applicationDidFinishLaunchingWithOptions');
-appDelegate.prototype.applicationDidFinishLaunchingWithOptions = function (
-    application: UIApplication,
-    launchOptions: NSDictionary<any, any>
-): boolean {
-    if (launchOptions != null) {
-        let urlOptions: string = launchOptions.valueForKey('UIApplicationLaunchOptionsURLKey');
-        if (urlOptions) {
-            let appURL = extractAppURL(urlOptions);
+enableMultipleOverridesFor(
+    appDelegate,
+    'applicationDidFinishLaunchingWithOptions',
+    function (
+        application: UIApplication,
+        launchOptions: NSDictionary<any, any>
+    ): boolean {
+        if (launchOptions != null) {
+            let urlOptions: string = launchOptions.valueForKey('UIApplicationLaunchOptionsURLKey');
+            if (urlOptions) {
+                let appURL = extractAppURL(urlOptions);
+                if (appURL != null) {
+                    getCallback()(appURL);
+                }
+            }
+        }
+
+        return true;
+    });
+
+enableMultipleOverridesFor(
+    appDelegate,
+    'applicationOpenURLOptions',
+    function (
+        application: UIApplication,
+        url: NSURL,
+        options: any
+    ): boolean {
+        const lastArgument = arguments[arguments.length - 1];
+        const previousResult = lastArgument !== options ? lastArgument : undefined;
+
+        if (!previousResult) {
+            let appURL = extractAppURL(url.absoluteString);
             if (appURL != null) {
                 getCallback()(appURL);
             }
+            return true;
         }
-    }
 
-    return true;
-};
+        return previousResult;
+    });
 
-enableMultipleOverridesFor(appDelegate, 'applicationOpenURLOptions');
-appDelegate.prototype.applicationOpenURLOptions = function (
-    application: UIApplication,
-    url: NSURL,
-    options: any
-): boolean {
-    const lastArgument = arguments[arguments.length - 1];
-    const previousResult = lastArgument !== options ? lastArgument : undefined;
+enableMultipleOverridesFor(
+    appDelegate,
+    'continueUserActivity',
+    function (
+        application: UIApplication,
+        userActivity: NSUserActivity
+    ): boolean {
+        if (userActivity.activityType === NSUserActivityTypeBrowsingWeb) {
 
-    if (!previousResult) {
-        let appURL = extractAppURL(url.absoluteString);
-        if (appURL != null) {
-            getCallback()(appURL);
+            let appURL = extractAppURL(userActivity.webpageURL);
+
+            if (appURL !== null) {
+                getCallback()(appURL);
+            }
         }
+
         return true;
-    }
-
-    return previousResult;
-};
-
-enableMultipleOverridesFor(appDelegate, 'continueUserActivity');
-appDelegate.prototype.continueUserActivity = function (
-    application: UIApplication,
-    userActivity: NSUserActivity
-): boolean {
-    if  (userActivity.activityType === NSUserActivityTypeBrowsingWeb) {
-
-        let appURL = extractAppURL(userActivity.webpageURL);
-
-        if (appURL !== null) {
-            getCallback()(appURL);
-        }
-    }
-
-    return true;
-};
-
+    });


### PR DESCRIPTION
The `tns-ios` runtime seems to have some trouble deciphering properties set with `Object.defineProperty` and do not seem to .
Use a more straightforward approach instead.

Tested and works on iOS 9 and 10