### PR TITLE
fix android handleOpenUrl isn't called

### DIFF
--- a/src/urlhandler.android.ts
+++ b/src/urlhandler.android.ts
@@ -23,7 +23,7 @@ export function handleIntent(intent: any) {
     }
 
 }
-application.android.on(application.AndroidApplication.activityStartedEvent, (args) => {
+application.android.on(application.AndroidApplication.activityNewIntentEvent, (args) => {
     setTimeout(() => {
         let intent: android.content.Intent = args.activity.getIntent();
         try {


### PR DESCRIPTION
Android fires "activityNewIntentEvent" if the activity is running in single mode

## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

### :dart: Relevant issues
<!-- Please add relevant opened issues -->

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] **I have added tests that prove my fix is effective or that my feature works**
- [ ] **New and existing unit tests pass locally with my changes**
- [ ] I have commented my code, particularly in hard-to-understand areas
