### PR TITLE
91

### DIFF
--- a/src/urlhandler.android.ts
+++ b/src/urlhandler.android.ts
@@ -13,7 +13,9 @@ export function handleIntent(intent: any) {
             try {
                 setTimeout(() => {
                   let result = getCallback()(appURL);
+                  // clear intent so that url will not be re-handled upon subsequent ActivityStarted event
                   intent.setAction("");
+                  intent.setData(null);
                   return result; 
                 });
             } catch (ignored) {

--- a/src/urlhandler.android.ts
+++ b/src/urlhandler.android.ts
@@ -11,7 +11,11 @@ export function handleIntent(intent: any) {
             (new String(intent.getAction()).valueOf() === new String(android.content.Intent.ACTION_MAIN).valueOf()
                 || new String(intent.getAction()).valueOf() === new String(android.content.Intent.ACTION_VIEW).valueOf())) {
             try {
-                setTimeout(() => getCallback()(appURL));
+                setTimeout(() => {
+                  let result = getCallback()(appURL);
+                  intent.setAction("");
+                  return result; 
+                });
             } catch (ignored) {
                 application.android.on(application.AndroidApplication.activityResultEvent, () => {
                     setTimeout(() => getCallback()(appURL));


### PR DESCRIPTION
## :memo: Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Added code on Android to clear the intent after the url is handled, so that the url will not be re-handled upon a subsequent ActivityStarted event, as described in issue 91. 

### :dart: Relevant issues
<!-- Please add relevant opened issues -->
https://github.com/hypery2k/nativescript-urlhandler/issues/91

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

### :scroll: Example code
```js

``` 

## :vertical_traffic_light: How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
1.  Receive and process deep link within app 
2.  From within app, open Contacts and return, so as to trigger ActivityStarted event 
3.  Verify that app is not re-entered with url that had been previously processed 
4.  Receive second deep link and verify url handled as expected 

## :checkered_flag: Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
